### PR TITLE
Fix loading hang on GitHub Pages

### DIFF
--- a/src/scenes/MainMenuScene.ts
+++ b/src/scenes/MainMenuScene.ts
@@ -187,18 +187,24 @@ export class MainMenuScene extends Phaser.Scene {
     
     if (settings.reduceMotion) return;
     
-    // Floating dust particles
-    const particles = this.add.particles(0, 0, 'particle', {
-      x: { min: 0, max: width },
-      y: { min: 0, max: height },
-      scale: { start: 0.5, end: 0 },
-      alpha: { start: 0.3, end: 0 },
-      speed: { min: 10, max: 30 },
-      angle: { min: -90, max: -90 },
-      lifespan: 4000,
-      frequency: 200,
-      blendMode: 'ADD'
-    });
+    // Floating dust particles (only if texture exists)
+    if (this.textures.exists('particle')) {
+      try {
+        this.add.particles(0, 0, 'particle', {
+          x: { min: 0, max: width },
+          y: { min: 0, max: height },
+          scale: { start: 0.5, end: 0 },
+          alpha: { start: 0.3, end: 0 },
+          speed: { min: 10, max: 30 },
+          angle: { min: -90, max: -90 },
+          lifespan: 4000,
+          frequency: 200,
+          blendMode: 'ADD'
+        });
+      } catch (e) {
+        console.warn('[MainMenu] Particle effect failed:', e);
+      }
+    }
     
     // Torch flicker effect (subtle brightness variation)
     this.tweens.add({

--- a/src/scenes/PreloadScene.ts
+++ b/src/scenes/PreloadScene.ts
@@ -1,6 +1,8 @@
 /**
- * PreloadScene - Robust asset loading with progress tracking
- * Handles GitHub Pages base paths and provides visual feedback
+ * PreloadScene - Bulletproof asset loading that NEVER hangs
+ * - Hard timeout ensures transition even if loading fails
+ * - Creates fallback textures for missing assets
+ * - Shows clear error messages with retry/continue options
  */
 
 import Phaser from 'phaser';
@@ -8,355 +10,391 @@ import { SaveSystem } from '../systems/SaveSystem';
 import { AssetGenerator } from '../ui/AssetGenerator';
 
 export class PreloadScene extends Phaser.Scene {
+  // UI Elements
   private loadingBar!: Phaser.GameObjects.Graphics;
-  private loadingBarBg!: Phaser.GameObjects.Graphics;
   private loadingText!: Phaser.GameObjects.Text;
   private progressText!: Phaser.GameObjects.Text;
   private errorText!: Phaser.GameObjects.Text;
-  private pulseGraphic!: Phaser.GameObjects.Graphics;
+  private retryButton!: Phaser.GameObjects.Container;
+  private continueButton!: Phaser.GameObjects.Container;
   
-  // Progress tracking
+  // State
   private currentProgress: number = 0;
-  private targetProgress: number = 0;
   private loadComplete: boolean = false;
-  private hasLoadErrors: boolean = false;
-  private assetsQueued: number = 0;
-  private assetsLoaded: number = 0;
+  private hasErrors: boolean = false;
+  private failedAssets: string[] = [];
+  private transitionStarted: boolean = false;
+  
+  // Timeout
+  private timeoutTimer?: Phaser.Time.TimerEvent;
+  private readonly LOAD_TIMEOUT_MS = 8000;
   
   // Bar dimensions
   private barWidth: number = 280;
-  private barHeight: number = 24;
-  private barX: number = 0;
-  private barY: number = 0;
-  
-  // Animation
-  private pulsePhase: number = 0;
+  private barHeight: number = 20;
+  private centerX: number = 0;
+  private centerY: number = 0;
   
   constructor() {
     super({ key: 'PreloadScene' });
   }
 
   init(): void {
-    // Reset all state
     this.currentProgress = 0;
-    this.targetProgress = 0;
     this.loadComplete = false;
-    this.hasLoadErrors = false;
-    this.assetsQueued = 0;
-    this.assetsLoaded = 0;
-    this.pulsePhase = 0;
-    
-    console.log('[PreloadScene] Initialized');
+    this.hasErrors = false;
+    this.failedAssets = [];
+    this.transitionStarted = false;
+    console.log('[Preload] === INIT ===');
   }
 
   preload(): void {
-    console.log('[PreloadScene] === PRELOAD START ===');
+    console.log('[Preload] === PRELOAD START ===');
     
-    // 1. Create loading UI FIRST (before anything else)
+    const { width, height } = this.cameras.main;
+    this.centerX = width / 2;
+    this.centerY = height / 2;
+    
+    // 1. Create UI first
     this.createLoadingUI();
     
-    // 2. Set up event listeners BEFORE queuing assets
-    this.setupLoadEvents();
+    // 2. Setup events BEFORE loading
+    this.setupLoaderEvents();
     
-    // 3. Queue actual asset files
+    // 3. Start hard timeout - will force transition even if loading hangs
+    this.startTimeout();
+    
+    // 4. Queue assets
     this.queueAssets();
     
-    // 4. Generate procedural textures (doesn't use loader)
+    // 5. Generate procedural textures (no loading needed)
     this.generateProceduralAssets();
-    
-    // 5. If no assets to load, mark as complete
-    if (this.assetsQueued === 0) {
-      console.log('[PreloadScene] No assets queued, completing immediately');
-      this.targetProgress = 1;
-      this.loadComplete = true;
-    }
   }
 
   private createLoadingUI(): void {
-    const { width, height } = this.cameras.main;
-    const centerX = width / 2;
-    const centerY = height / 2;
+    // Background
+    this.add.rectangle(this.centerX, this.centerY, this.cameras.main.width, this.cameras.main.height, 0x1a1410);
 
-    // Store bar position
-    this.barX = centerX - this.barWidth / 2;
-    this.barY = centerY + 30;
-
-    // Dark background
-    this.add.rectangle(centerX, centerY, width, height, 0x1a1410);
-
-    // Title with shadow
-    this.add.text(centerX + 2, centerY - 92, 'BLOODLINE ARENA', {
+    // Title
+    this.add.text(this.centerX, this.centerY - 80, 'BLOODLINE ARENA', {
       fontFamily: 'Georgia, serif',
-      fontSize: '28px',
-      color: '#000000'
-    }).setOrigin(0.5).setAlpha(0.5);
-    
-    this.add.text(centerX, centerY - 94, 'BLOODLINE ARENA', {
-      fontFamily: 'Georgia, serif',
-      fontSize: '28px',
+      fontSize: '26px',
       color: '#c9a959',
       stroke: '#000000',
-      strokeThickness: 2
+      strokeThickness: 3
     }).setOrigin(0.5);
 
     // Subtitle
-    this.add.text(centerX, centerY - 55, 'Blood. Honor. Legacy.', {
+    this.add.text(this.centerX, this.centerY - 45, 'Blood. Honor. Legacy.', {
       fontFamily: 'Georgia, serif',
-      fontSize: '14px',
+      fontSize: '13px',
       color: '#8b7355',
       fontStyle: 'italic'
     }).setOrigin(0.5);
 
-    // Loading bar container (outer border)
-    this.loadingBarBg = this.add.graphics();
-    this.loadingBarBg.fillStyle(0x5a4a3a, 1);
-    this.loadingBarBg.fillRoundedRect(
-      this.barX - 4,
-      this.barY - 4,
-      this.barWidth + 8,
-      this.barHeight + 8,
-      6
-    );
-    // Inner background
-    this.loadingBarBg.fillStyle(0x1a1410, 1);
-    this.loadingBarBg.fillRoundedRect(
-      this.barX,
-      this.barY,
-      this.barWidth,
-      this.barHeight,
-      4
-    );
-
-    // Pulse effect graphic (for indeterminate state)
-    this.pulseGraphic = this.add.graphics();
+    // Loading bar background
+    const barX = this.centerX - this.barWidth / 2;
+    const barY = this.centerY + 10;
     
+    const barBg = this.add.graphics();
+    barBg.fillStyle(0x5a4a3a, 1);
+    barBg.fillRoundedRect(barX - 3, barY - 3, this.barWidth + 6, this.barHeight + 6, 5);
+    barBg.fillStyle(0x2a1f1a, 1);
+    barBg.fillRoundedRect(barX, barY, this.barWidth, this.barHeight, 4);
+
     // Loading bar fill
     this.loadingBar = this.add.graphics();
     
-    // Loading text
-    this.loadingText = this.add.text(centerX, centerY + 70, 'Initializing...', {
+    // Progress text
+    this.progressText = this.add.text(this.centerX, barY + this.barHeight / 2, '0%', {
       fontFamily: 'Georgia, serif',
-      fontSize: '13px',
+      fontSize: '11px',
+      color: '#ffffff'
+    }).setOrigin(0.5);
+    
+    // Loading status text
+    this.loadingText = this.add.text(this.centerX, this.centerY + 55, 'Loading...', {
+      fontFamily: 'Georgia, serif',
+      fontSize: '12px',
       color: '#8b7355'
     }).setOrigin(0.5);
 
-    // Progress percentage
-    this.progressText = this.add.text(centerX, centerY + 30 + this.barHeight / 2, '0%', {
+    // Error text (initially hidden)
+    this.errorText = this.add.text(this.centerX, this.centerY + 80, '', {
       fontFamily: 'Georgia, serif',
       fontSize: '11px',
-      color: '#c9a959'
+      color: '#cc6666',
+      align: 'center'
     }).setOrigin(0.5);
-
-    // Error text (hidden initially)
-    this.errorText = this.add.text(centerX, centerY + 95, '', {
-      fontFamily: 'Georgia, serif',
-      fontSize: '10px',
-      color: '#aa4444'
-    }).setOrigin(0.5);
-    
-    // Draw initial state
-    this.updateProgressBar(0);
   }
 
-  private setupLoadEvents(): void {
-    // Progress event
+  private setupLoaderEvents(): void {
+    // Progress
     this.load.on('progress', (value: number) => {
-      this.targetProgress = value;
-      this.assetsLoaded = Math.floor(value * this.assetsQueued);
-      console.log(`[PreloadScene] Progress: ${Math.floor(value * 100)}% (${this.assetsLoaded}/${this.assetsQueued})`);
+      this.currentProgress = value;
+      this.updateProgressBar();
+      console.log(`[Preload] Progress: ${Math.floor(value * 100)}%`);
     });
 
-    // Individual file complete
-    this.load.on('filecomplete', (key: string, type: string) => {
-      console.log(`[PreloadScene] ✓ Loaded: ${key} (${type})`);
+    // File loaded successfully
+    this.load.on('filecomplete', (key: string) => {
+      console.log(`[Preload] ✓ ${key}`);
       this.loadingText.setText(`Loaded: ${key}`);
     });
 
-    // Error handling
+    // File failed to load
     this.load.on('loaderror', (file: Phaser.Loader.File) => {
-      const errorMsg = `✗ Failed: ${file.key}`;
-      console.error(`[PreloadScene] ${errorMsg} - URL: ${file.src}`);
-      this.hasLoadErrors = true;
-      this.errorText.setText(`⚠ ${file.key} failed to load`);
+      console.error(`[Preload] ✗ FAILED: ${file.key} (${file.src})`);
+      this.hasErrors = true;
+      this.failedAssets.push(file.key);
+      this.errorText.setText(`Failed: ${file.key}`);
+      
+      // Create fallback texture immediately
+      this.createFallbackTexture(file.key);
     });
 
-    // Complete event
+    // All files complete (success or fail)
     this.load.once('complete', () => {
-      console.log('[PreloadScene] === LOAD COMPLETE ===');
+      console.log('[Preload] === LOADER COMPLETE ===');
       this.loadComplete = true;
-      this.targetProgress = 1;
-      this.loadingText.setText('Ready!');
+      this.currentProgress = 1;
+      this.updateProgressBar();
+      
+      // Clear timeout since we completed normally
+      if (this.timeoutTimer) {
+        this.timeoutTimer.destroy();
+      }
+      
+      if (this.failedAssets.length > 0) {
+        this.showErrorUI();
+      } else {
+        this.startTransition();
+      }
+    });
+  }
+
+  private startTimeout(): void {
+    console.log(`[Preload] Starting ${this.LOAD_TIMEOUT_MS}ms timeout`);
+    
+    this.timeoutTimer = this.time.delayedCall(this.LOAD_TIMEOUT_MS, () => {
+      if (!this.loadComplete && !this.transitionStarted) {
+        console.warn('[Preload] ⚠ TIMEOUT - forcing transition');
+        this.loadingText.setText('Loading timed out');
+        
+        // Create fallbacks for any still-pending assets
+        this.createAllFallbacks();
+        
+        // Show error UI with continue option
+        this.showErrorUI();
+      }
     });
   }
 
   private queueAssets(): void {
-    // Get base URL for GitHub Pages compatibility
-    const baseUrl = import.meta.env.BASE_URL || '/';
-    console.log(`[PreloadScene] Base URL: "${baseUrl}"`);
+    const base = import.meta.env.BASE_URL || '/';
+    console.log(`[Preload] Base URL: ${base}`);
     
-    // Define assets to load
-    const svgAssets = [
-      { key: 'ui_panel', path: 'assets/ui/panel.svg' },
-      { key: 'ui_button', path: 'assets/ui/button.svg' },
-      { key: 'ui_frame', path: 'assets/ui/frame.svg' },
-      { key: 'overlay_vignette', path: 'assets/overlays/vignette.svg' },
-      { key: 'overlay_grain', path: 'assets/overlays/grain.svg' },
-      { key: 'arena_background', path: 'assets/arena/background.svg' },
-      { key: 'icon_main', path: 'assets/icons/icon.svg' },
+    // Core assets - these are what we try to load
+    const assets = [
+      { key: 'ui_panel', path: `${base}assets/ui/panel.svg` },
+      { key: 'ui_button', path: `${base}assets/ui/button.svg` },
+      { key: 'ui_frame', path: `${base}assets/ui/frame.svg` },
+      { key: 'overlay_vignette', path: `${base}assets/overlays/vignette.svg` },
+      { key: 'overlay_grain', path: `${base}assets/overlays/grain.svg` },
+      { key: 'arena_bg', path: `${base}assets/arena/background.svg` },
+      { key: 'icon_main', path: `${base}assets/icons/icon.svg` },
     ];
     
-    // Queue each asset
-    svgAssets.forEach(asset => {
-      const fullPath = `${baseUrl}${asset.path}`;
-      console.log(`[PreloadScene] Queuing: ${asset.key} -> ${fullPath}`);
-      this.load.svg(asset.key, fullPath);
+    assets.forEach(a => {
+      console.log(`[Preload] Queuing: ${a.key}`);
+      this.load.svg(a.key, a.path);
     });
     
-    this.assetsQueued = svgAssets.length;
-    console.log(`[PreloadScene] Total assets queued: ${this.assetsQueued}`);
+    console.log(`[Preload] Queued ${assets.length} assets`);
   }
 
   private generateProceduralAssets(): void {
-    // Generate textures programmatically (no network requests)
-    const generator = new AssetGenerator(this);
-    generator.generateUIAssets();
-    generator.generatePortraitAssets();
-    generator.generateArenaAssets();
-    generator.generateEffectAssets();
-    generator.generateIconAssets();
-    console.log('[PreloadScene] Procedural assets generated');
-  }
-
-  update(time: number, delta: number): void {
-    // Smooth progress animation
-    const smoothSpeed = 0.05;
-    if (this.currentProgress < this.targetProgress) {
-      this.currentProgress += (this.targetProgress - this.currentProgress) * smoothSpeed + 0.001;
-      if (this.currentProgress > this.targetProgress) {
-        this.currentProgress = this.targetProgress;
-      }
+    try {
+      const generator = new AssetGenerator(this);
+      generator.generateUIAssets();
+      generator.generatePortraitAssets();
+      generator.generateArenaAssets();
+      generator.generateEffectAssets();
+      generator.generateIconAssets();
+      console.log('[Preload] Procedural assets generated');
+    } catch (e) {
+      console.error('[Preload] Error generating procedural assets:', e);
     }
-    
-    // Indeterminate pulse animation when stuck
-    this.pulsePhase += delta * 0.003;
-    
-    // If progress is stuck at 0 or very low, show indeterminate animation
-    const showPulse = !this.loadComplete && this.currentProgress < 0.05;
-    
-    // Update visuals
-    this.updateProgressBar(this.currentProgress);
-    this.updatePulseEffect(showPulse);
-    this.updateHTMLLoadingBar(this.currentProgress);
   }
 
-  private updateProgressBar(value: number): void {
+  private updateProgressBar(): void {
     if (!this.loadingBar) return;
     
+    const barX = this.centerX - this.barWidth / 2;
+    const barY = this.centerY + 10;
+    const fillWidth = (this.barWidth - 4) * this.currentProgress;
+    
     this.loadingBar.clear();
-    
-    const fillWidth = Math.max(0, (this.barWidth - 4) * Math.min(value, 1));
-    
     if (fillWidth > 0) {
-      // Gradient fill from dark to gold
-      this.loadingBar.fillGradientStyle(
-        0x8b4513, 0xc9a959,
-        0x8b4513, 0xc9a959
-      );
-      this.loadingBar.fillRoundedRect(
-        this.barX + 2,
-        this.barY + 2,
-        fillWidth,
-        this.barHeight - 4,
-        3
-      );
-      
-      // Highlight on top
-      this.loadingBar.fillStyle(0xffffff, 0.1);
-      this.loadingBar.fillRoundedRect(
-        this.barX + 2,
-        this.barY + 2,
-        fillWidth,
-        (this.barHeight - 4) / 2,
-        3
-      );
+      this.loadingBar.fillStyle(0xc9a959, 1);
+      this.loadingBar.fillRoundedRect(barX + 2, barY + 2, fillWidth, this.barHeight - 4, 3);
     }
-
-    // Update percentage text
-    const percent = Math.floor(Math.min(value, 1) * 100);
-    if (this.progressText) {
-      this.progressText.setText(`${percent}%`);
-    }
-  }
-  
-  private updatePulseEffect(show: boolean): void {
-    if (!this.pulseGraphic) return;
     
-    this.pulseGraphic.clear();
-    
-    if (show) {
-      // Animated pulse effect when loading is indeterminate
-      const pulseWidth = 60;
-      const pulseX = this.barX + 2 + (Math.sin(this.pulsePhase) * 0.5 + 0.5) * (this.barWidth - pulseWidth - 4);
-      const alpha = 0.3 + Math.sin(this.pulsePhase * 2) * 0.2;
-      
-      this.pulseGraphic.fillStyle(0xc9a959, alpha);
-      this.pulseGraphic.fillRoundedRect(
-        pulseX,
-        this.barY + 2,
-        pulseWidth,
-        this.barHeight - 4,
-        3
-      );
-    }
+    this.progressText.setText(`${Math.floor(this.currentProgress * 100)}%`);
   }
 
-  private updateHTMLLoadingBar(value: number): void {
-    // Sync with HTML loading bar if it exists
-    const htmlBar = document.getElementById('loading-bar');
-    const htmlText = document.getElementById('loading-text');
+  private createFallbackTexture(key: string): void {
+    // Create a simple colored rectangle as fallback
+    if (this.textures.exists(key)) return;
     
-    if (htmlBar) {
-      htmlBar.style.width = `${Math.min(value, 1) * 100}%`;
-    }
-    if (htmlText) {
-      htmlText.textContent = `Loading... ${Math.floor(Math.min(value, 1) * 100)}%`;
-    }
+    const graphics = this.make.graphics({ x: 0, y: 0 });
+    graphics.fillStyle(0x3a2a1a, 1);
+    graphics.fillRect(0, 0, 64, 64);
+    graphics.lineStyle(2, 0x5a4a3a, 1);
+    graphics.strokeRect(1, 1, 62, 62);
+    graphics.generateTexture(key, 64, 64);
+    graphics.destroy();
+    
+    console.log(`[Preload] Created fallback texture: ${key}`);
   }
 
-  create(): void {
-    console.log('[PreloadScene] === CREATE PHASE ===');
+  private createAllFallbacks(): void {
+    // Create fallbacks for all expected assets
+    const expectedKeys = [
+      'ui_panel', 'ui_button', 'ui_frame',
+      'overlay_vignette', 'overlay_grain',
+      'arena_bg', 'icon_main'
+    ];
+    
+    expectedKeys.forEach(key => {
+      if (!this.textures.exists(key)) {
+        this.createFallbackTexture(key);
+      }
+    });
+  }
+
+  private showErrorUI(): void {
+    const errorCount = this.failedAssets.length;
+    
+    if (errorCount > 0) {
+      this.errorText.setText(`${errorCount} asset(s) failed to load`);
+    } else {
+      this.errorText.setText('Loading issues detected');
+    }
+    
+    // Create Continue button
+    this.continueButton = this.createButton(
+      this.centerX,
+      this.centerY + 130,
+      'Continue Anyway',
+      () => this.startTransition()
+    );
+    
+    // Create Retry button
+    this.retryButton = this.createButton(
+      this.centerX,
+      this.centerY + 175,
+      'Retry',
+      () => this.retryLoading()
+    );
+    
+    this.loadingText.setText('Some assets failed to load');
+  }
+
+  private createButton(x: number, y: number, text: string, callback: () => void): Phaser.GameObjects.Container {
+    const container = this.add.container(x, y);
+    
+    const bg = this.add.graphics();
+    bg.fillStyle(0x4a3a2a, 1);
+    bg.fillRoundedRect(-80, -18, 160, 36, 6);
+    bg.lineStyle(2, 0xc9a959, 1);
+    bg.strokeRoundedRect(-80, -18, 160, 36, 6);
+    
+    const label = this.add.text(0, 0, text, {
+      fontFamily: 'Georgia, serif',
+      fontSize: '13px',
+      color: '#c9a959'
+    }).setOrigin(0.5);
+    
+    container.add([bg, label]);
+    
+    // Make interactive
+    const hitArea = new Phaser.Geom.Rectangle(-80, -18, 160, 36);
+    bg.setInteractive(hitArea, Phaser.Geom.Rectangle.Contains);
+    bg.on('pointerdown', callback);
+    bg.on('pointerover', () => label.setColor('#ffffff'));
+    bg.on('pointerout', () => label.setColor('#c9a959'));
+    
+    return container;
+  }
+
+  private retryLoading(): void {
+    console.log('[Preload] Retrying...');
+    this.scene.restart();
+  }
+
+  private startTransition(): void {
+    if (this.transitionStarted) return;
+    this.transitionStarted = true;
+    
+    console.log('[Preload] === STARTING TRANSITION ===');
+    
+    // Clear timeout
+    if (this.timeoutTimer) {
+      this.timeoutTimer.destroy();
+    }
+    
+    // Hide buttons if shown
+    if (this.retryButton) this.retryButton.setVisible(false);
+    if (this.continueButton) this.continueButton.setVisible(false);
     
     // Initialize save system
-    SaveSystem.load();
-    SaveSystem.startAutoSave(30000);
+    try {
+      SaveSystem.load();
+      SaveSystem.startAutoSave(30000);
+    } catch (e) {
+      console.error('[Preload] SaveSystem error:', e);
+    }
 
     // Hide HTML loading screen
     const loadingScreen = document.getElementById('loading-screen');
     if (loadingScreen) {
       loadingScreen.style.opacity = '0';
-      loadingScreen.style.transition = 'opacity 0.3s';
-      setTimeout(() => {
-        loadingScreen.style.display = 'none';
-      }, 300);
+      loadingScreen.style.pointerEvents = 'none';
     }
 
-    // Log any errors
-    if (this.hasLoadErrors) {
-      console.warn('[PreloadScene] ⚠ Completed with load errors');
-    }
-
-    // Ensure we show 100% before transitioning
+    this.loadingText.setText('Starting game...');
     this.currentProgress = 1;
-    this.updateProgressBar(1);
-    this.loadingText.setText('Starting...');
+    this.updateProgressBar();
 
-    // Delay before transition
-    this.time.delayedCall(400, () => {
-      this.cameras.main.fadeOut(400, 0, 0, 0);
-      this.cameras.main.once('camerafadeoutcomplete', () => {
-        console.log('[PreloadScene] Transitioning to MainMenuScene');
-        this.scene.start('MainMenuScene');
-      });
+    // Transition with a simple delay (no fade dependency)
+    this.time.delayedCall(300, () => {
+      console.log('[Preload] >>> scene.start("MainMenuScene")');
+      this.scene.start('MainMenuScene');
     });
+  }
+
+  // Fallback update loop to catch any edge cases
+  update(time: number, delta: number): void {
+    // Safety: if loadComplete but not transitioned after 2 seconds, force it
+    if (this.loadComplete && !this.transitionStarted) {
+      // This shouldn't happen, but just in case
+      console.warn('[Preload] Safety transition triggered');
+      this.startTransition();
+    }
+  }
+
+  create(): void {
+    // This runs after preload completes
+    // Most logic is handled by loader events, but ensure transition starts
+    console.log('[Preload] === CREATE ===');
+    
+    if (!this.transitionStarted && this.loadComplete) {
+      if (this.failedAssets.length > 0) {
+        this.showErrorUI();
+      } else {
+        this.startTransition();
+      }
+    }
   }
 }


### PR DESCRIPTION
PreloadScene changes:
- Added 8-second hard timeout to force transition if loading hangs
- Creates fallback textures for any failed/missing assets
- Shows Retry/Continue buttons on load errors
- Simplified transition logic - no longer depends on camera fade
- Better error logging with asset URLs

MainMenuScene changes:
- Added texture existence check before creating particle effects
- Wrapped particle creation in try-catch to prevent crashes
- Game now survives missing textures gracefully

The game will now ALWAYS leave the loading screen, either:
1. After successful load
2. After timeout with error UI and Continue option
3. After user clicks Continue/Retry buttons