### PR TITLE
Add procedural loot system with endless procedural weapons/armor, shop stock and drops

### DIFF
--- a/src/scenes/ShopScene.ts
+++ b/src/scenes/ShopScene.ts
@@ -5,19 +5,17 @@
 import Phaser from 'phaser';
 import { SaveSystem } from '../systems/SaveSystem';
 import { Fighter } from '../systems/FighterSystem';
-import { WEAPONS_DATA as OLD_WEAPONS, ARMOR_DATA as OLD_ARMOR, COMBAT_ITEMS } from '../data/CombatData';
-import { WEAPONS_DATA } from '../data/WeaponsData';
-import { ARMOR_DATA } from '../data/ArmorData';
+import { COMBAT_ITEMS } from '../data/CombatData';
 import { 
   createItemInstance, 
-  createAffixedItemInstance, 
   ItemInstance, 
   getItemName,
-  getItemData 
+  getItemData,
+  generateRandomWeapon,
+  generateRandomArmor
 } from '../systems/InventorySystem';
 import { getAffixSummary, hasAffixes } from '../systems/AffixSystem';
 import { UIHelper } from '../ui/UIHelper';
-import { RNG } from '../systems/RNGSystem';
 
 export class ShopScene extends Phaser.Scene {
   private gold!: number;
@@ -60,32 +58,17 @@ export class ShopScene extends Phaser.Scene {
     const numWeapons = 3 + Math.floor(meta.promoterLevel / 2);
     const numArmor = 3 + Math.floor(meta.promoterLevel / 2);
     
-    // Filter weapons/armor by league availability
-    const leagueOrder = ['bronze', 'silver', 'gold'];
-    const leagueIdx = leagueOrder.indexOf(league);
-    
     this.shopStock = [];
     
     // Generate weapons as ItemInstances with affixes
-    const availableWeapons = WEAPONS_DATA.filter(w => 
-      leagueOrder.indexOf(w.leagueMin) <= leagueIdx
-    );
-    const weapons = RNG.shuffle([...availableWeapons]).slice(0, numWeapons);
-    weapons.forEach(w => {
-      // Create item instance with affixes rolled based on rarity and league
-      const instance = createAffixedItemInstance(w.id, 'weapon', w.rarity, league);
-      this.shopStock.push(instance);
-    });
+    for (let i = 0; i < numWeapons; i++) {
+      this.shopStock.push(generateRandomWeapon(league, true));
+    }
     
     // Generate armor as ItemInstances with affixes
-    const availableArmor = ARMOR_DATA.filter(a => 
-      leagueOrder.indexOf(a.leagueMin) <= leagueIdx
-    );
-    const armor = RNG.shuffle([...availableArmor]).slice(0, numArmor);
-    armor.forEach(a => {
-      const instance = createAffixedItemInstance(a.id, 'armor', a.rarity, league, a.slot);
-      this.shopStock.push(instance);
-    });
+    for (let i = 0; i < numArmor; i++) {
+      this.shopStock.push(generateRandomArmor(league, undefined, true));
+    }
     
     // Consumables (no affixes)
     COMBAT_ITEMS.forEach(item => {

--- a/src/systems/LootSystem.ts
+++ b/src/systems/LootSystem.ts
@@ -1,0 +1,54 @@
+/**
+ * LootSystem - Generates loot drops after combat
+ */
+
+import { RNG } from './RNGSystem';
+import { ItemInstance, generateRandomWeapon, generateRandomArmor, generateRandomTrinket, generateRandomConsumable } from './InventorySystem';
+
+export interface LootContext {
+  league: 'bronze' | 'silver' | 'gold';
+  crowdHype: number;
+  consecutiveWins: number;
+}
+
+export function generateLootDrops(context: LootContext): ItemInstance[] {
+  const drops: ItemInstance[] = [];
+  const hypeBonus = Math.min(0.35, context.crowdHype / 300);
+  const baseDrops = 1 + (context.consecutiveWins >= 3 ? 1 : 0);
+
+  for (let i = 0; i < baseDrops; i++) {
+    drops.push(generateLootItem(context.league));
+  }
+
+  if (RNG.chance(0.25 + hypeBonus)) {
+    drops.push(generateLootItem(context.league));
+  }
+
+  if (context.consecutiveWins >= 5 && RNG.chance(0.35)) {
+    drops.push(generateLootItem(context.league));
+  }
+
+  return drops;
+}
+
+function generateLootItem(league: 'bronze' | 'silver' | 'gold'): ItemInstance {
+  const category = RNG.weightedPick([
+    ['weapon', 35],
+    ['armor', 35],
+    ['trinket', 15],
+    ['consumable', 15]
+  ] as const);
+
+  switch (category) {
+    case 'weapon':
+      return generateRandomWeapon(league, true);
+    case 'armor':
+      return generateRandomArmor(league, undefined, true);
+    case 'trinket':
+      return generateRandomTrinket(league);
+    case 'consumable':
+      return generateRandomConsumable(league);
+    default:
+      return generateRandomWeapon(league, true);
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide an endless variety of equipment so shops and drops can yield unique weapons and armor every run. 
- Make loot rewards scale with league, crowd hype and win streaks so rewards feel dynamic and meaningful.

### Description

- Implemented deterministic procedural gear generation: added `createProceduralWeaponId`/`createProceduralArmorId` and builders that reconstruct `WeaponData`/`ArmorData` from a seed (files: `src/data/WeaponsData.ts`, `src/data/ArmorData.ts`).
- Added procedural generation entry points and rollout into inventory: `generateProceduralWeapon`/`generateProceduralArmor` plus rarity/weight helpers and RNG integration (file: `src/systems/InventorySystem.ts`).
- Updated the shop to use the new generation pipeline and include procedural gear in stock (file: `src/scenes/ShopScene.ts`).
- New `LootSystem` that rolls multi-category drops (weapons, armor, trinkets, consumables) influenced by league, crowd hype and consecutive wins, and returns ItemInstances (file: `src/systems/LootSystem.ts`).
- Wired combat -> results so crowd hype is passed and generated loot is awarded and displayed on the results screen (`src/scenes/FightScene.ts`, `src/scenes/ResultsScene.ts`).
- Kept existing affix pipeline intact by creating procedural base item IDs that still go through `createAffixedItemInstance` when appropriate (inventory/affix compatibility retained).

### Testing

- Launched dev server with `npm run dev` (Vite) and confirmed the server started and served the client (Vite reported ready). This completed successfully (non-fatal `xdg-open` warning in the environment). 
- Ran a Playwright navigation script that started the `ResultsScene` with a sample payload and captured a screenshot at `artifacts/results-loot.png`, validating that loot drops are generated, saved to the run inventory and rendered on the results screen; the script completed successfully and saved `artifacts/results-loot.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983c5e910c08324bbc1be2f1c4d857d)