### PR TITLE
Deepen combat tactics with momentum, posture and procedural loot integration

### DIFF
--- a/src/scenes/ShopScene.ts
+++ b/src/scenes/ShopScene.ts
@@ -5,19 +5,17 @@
 import Phaser from 'phaser';
 import { SaveSystem } from '../systems/SaveSystem';
 import { Fighter } from '../systems/FighterSystem';
-import { WEAPONS_DATA as OLD_WEAPONS, ARMOR_DATA as OLD_ARMOR, COMBAT_ITEMS } from '../data/CombatData';
-import { WEAPONS_DATA } from '../data/WeaponsData';
-import { ARMOR_DATA } from '../data/ArmorData';
+import { COMBAT_ITEMS } from '../data/CombatData';
 import { 
   createItemInstance, 
-  createAffixedItemInstance, 
   ItemInstance, 
   getItemName,
-  getItemData 
+  getItemData,
+  generateRandomWeapon,
+  generateRandomArmor
 } from '../systems/InventorySystem';
 import { getAffixSummary, hasAffixes } from '../systems/AffixSystem';
 import { UIHelper } from '../ui/UIHelper';
-import { RNG } from '../systems/RNGSystem';
 
 export class ShopScene extends Phaser.Scene {
   private gold!: number;
@@ -60,32 +58,17 @@ export class ShopScene extends Phaser.Scene {
     const numWeapons = 3 + Math.floor(meta.promoterLevel / 2);
     const numArmor = 3 + Math.floor(meta.promoterLevel / 2);
     
-    // Filter weapons/armor by league availability
-    const leagueOrder = ['bronze', 'silver', 'gold'];
-    const leagueIdx = leagueOrder.indexOf(league);
-    
     this.shopStock = [];
     
     // Generate weapons as ItemInstances with affixes
-    const availableWeapons = WEAPONS_DATA.filter(w => 
-      leagueOrder.indexOf(w.leagueMin) <= leagueIdx
-    );
-    const weapons = RNG.shuffle([...availableWeapons]).slice(0, numWeapons);
-    weapons.forEach(w => {
-      // Create item instance with affixes rolled based on rarity and league
-      const instance = createAffixedItemInstance(w.id, 'weapon', w.rarity, league);
-      this.shopStock.push(instance);
-    });
+    for (let i = 0; i < numWeapons; i++) {
+      this.shopStock.push(generateRandomWeapon(league, true));
+    }
     
     // Generate armor as ItemInstances with affixes
-    const availableArmor = ARMOR_DATA.filter(a => 
-      leagueOrder.indexOf(a.leagueMin) <= leagueIdx
-    );
-    const armor = RNG.shuffle([...availableArmor]).slice(0, numArmor);
-    armor.forEach(a => {
-      const instance = createAffixedItemInstance(a.id, 'armor', a.rarity, league, a.slot);
-      this.shopStock.push(instance);
-    });
+    for (let i = 0; i < numArmor; i++) {
+      this.shopStock.push(generateRandomArmor(league, undefined, true));
+    }
     
     // Consumables (no affixes)
     COMBAT_ITEMS.forEach(item => {

--- a/src/systems/LootSystem.ts
+++ b/src/systems/LootSystem.ts
@@ -1,0 +1,54 @@
+/**
+ * LootSystem - Generates loot drops after combat
+ */
+
+import { RNG } from './RNGSystem';
+import { ItemInstance, generateRandomWeapon, generateRandomArmor, generateRandomTrinket, generateRandomConsumable } from './InventorySystem';
+
+export interface LootContext {
+  league: 'bronze' | 'silver' | 'gold';
+  crowdHype: number;
+  consecutiveWins: number;
+}
+
+export function generateLootDrops(context: LootContext): ItemInstance[] {
+  const drops: ItemInstance[] = [];
+  const hypeBonus = Math.min(0.35, context.crowdHype / 300);
+  const baseDrops = 1 + (context.consecutiveWins >= 3 ? 1 : 0);
+
+  for (let i = 0; i < baseDrops; i++) {
+    drops.push(generateLootItem(context.league));
+  }
+
+  if (RNG.chance(0.25 + hypeBonus)) {
+    drops.push(generateLootItem(context.league));
+  }
+
+  if (context.consecutiveWins >= 5 && RNG.chance(0.35)) {
+    drops.push(generateLootItem(context.league));
+  }
+
+  return drops;
+}
+
+function generateLootItem(league: 'bronze' | 'silver' | 'gold'): ItemInstance {
+  const category = RNG.weightedPick([
+    ['weapon', 35],
+    ['armor', 35],
+    ['trinket', 15],
+    ['consumable', 15]
+  ] as const);
+
+  switch (category) {
+    case 'weapon':
+      return generateRandomWeapon(league, true);
+    case 'armor':
+      return generateRandomArmor(league, undefined, true);
+    case 'trinket':
+      return generateRandomTrinket(league);
+    case 'consumable':
+      return generateRandomConsumable(league);
+    default:
+      return generateRandomWeapon(league, true);
+  }
+}


### PR DESCRIPTION
### Motivation
- Give combat more tactical depth by introducing momentum and posture systems to enable guard-break and pressure play patterns. 
- Make status upkeep and zone-targeting more meaningful by adding posture decay, zone-specific stamina effects, and stun handling. 
- Surface procedural gear and loot into shops/results so drops and vendor stock include varied procedural weapons/armor.

### Description
- Added momentum and posture to `CombatantState` and new guard-break/stun logic in `src/systems/CombatSystem.ts`, including `momentumStacks`, `posture`, `maxPosture`, posture regeneration and momentum decay, and stun skip handling. 
- Expanded attack resolution in `executeAttack` to apply momentum-driven accuracy/damage/crit bonuses, follow-up bonuses for tactical transitions (e.g. guard->light, dodge->heavy), zone-specific stamina shred for leg hits, and posture damage that can trigger `stun`. 
- Adjusted `executeSpecial`, `executeGuard`, `executeDodge`, `executeItem`, `processTurnEnd`, `attemptPerfectParry`, and `nextTurn` in `CombatSystem` to track and modify momentum/posture and new status upkeep (poison/cripple stamina effects). 
- Added procedural weapon and armor builders and IDs in `src/data/WeaponsData.ts` and `src/data/ArmorData.ts` with seeded name/stats/perk generation via `createProceduralWeaponId`/`createProceduralArmorId` and `buildProceduralWeapon`/`buildProceduralArmor`. 
- Integrated procedural item generation into `src/systems/InventorySystem.ts` by adding rarity roll helpers, `generateRandomWeapon`/`generateRandomArmor` fallbacks, and `generateProceduralWeapon`/`generateProceduralArmor` that return `ItemInstance`s (with affix support). 
- New `src/systems/LootSystem.ts` that produces multi-category drops influenced by `league`, `crowdHype` and `consecutiveWins`, and wired results display to show and persist loot in `src/scenes/ResultsScene.ts`. 
- Updated UI/UX in `src/scenes/FightScene.ts` and `src/scenes/ShopScene.ts` to expose tactical info: momentum/parry indicators, intent text, injury meters, resource summaries, combat feed, improved arena visuals, and to use procedural generation for shop stock.

### Testing
- No automated tests were executed for this change (logic and feature additions only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983c5e910c08324bbc1be2f1c4d857d)