### PR TITLE
Enhance UI/graphics and wire up procedural loot + combat HUD polish

### DIFF
--- a/src/scenes/MainMenuScene.ts
+++ b/src/scenes/MainMenuScene.ts
@@ -41,23 +41,37 @@ export class MainMenuScene extends Phaser.Scene {
   private createBackground(): void {
     const { width, height } = this.cameras.main;
     
-    // Dark gradient background
+    // Dark gradient background with depth
     const bg = this.add.graphics();
-    bg.fillGradientStyle(0x1a1410, 0x1a1410, 0x2a1f1a, 0x2a1f1a);
+    bg.fillGradientStyle(0x120d0a, 0x1c1410, 0x2c2018, 0x1a1410);
     bg.fillRect(0, 0, width, height);
+
+    // Subtle radial glow
+    const glow = this.add.graphics();
+    glow.fillStyle(0xffd37a, 0.12);
+    glow.fillCircle(width * 0.5, height * 0.3, width * 0.35);
+    glow.fillStyle(0x7a4b1d, 0.18);
+    glow.fillCircle(width * 0.5, height * 0.35, width * 0.2);
     
     // Add parchment texture overlay
     if (this.textures.exists('parchment_overlay')) {
       const overlay = this.add.image(width / 2, height / 2, 'parchment_overlay');
-      overlay.setAlpha(0.1);
+      overlay.setAlpha(0.12);
       overlay.setDisplaySize(width, height);
     }
+
+    // Decorative frame
+    const frame = this.add.graphics();
+    frame.lineStyle(3, 0x7a5b2e, 0.7);
+    frame.strokeRoundedRect(16, 18, width - 32, height - 36, 16);
+    frame.lineStyle(1, 0x2a1f1a, 0.9);
+    frame.strokeRoundedRect(22, 26, width - 44, height - 52, 14);
     
     // Add vignette
     if (this.textures.exists('vignette')) {
       const vignette = this.add.image(width / 2, height / 2, 'vignette');
       vignette.setDisplaySize(width, height);
-      vignette.setAlpha(0.5);
+      vignette.setAlpha(0.6);
     }
   }
 
@@ -66,37 +80,62 @@ export class MainMenuScene extends Phaser.Scene {
     const centerX = width / 2;
     
     // Main title
-    const title = this.add.text(centerX, 120, 'BLOODLINE', {
+    const title = this.add.text(centerX, 110, 'BLOODLINE', {
       fontFamily: 'Georgia, serif',
-      fontSize: '48px',
-      color: '#c9a959',
+      fontSize: '52px',
+      color: '#f1d28a',
       stroke: '#000000',
-      strokeThickness: 6
+      strokeThickness: 7
     }).setOrigin(0.5);
     
-    const subtitle = this.add.text(centerX, 175, 'ARENA', {
+    const subtitle = this.add.text(centerX, 170, 'ARENA', {
       fontFamily: 'Georgia, serif',
-      fontSize: '36px',
-      color: '#8b7355',
+      fontSize: '38px',
+      color: '#b98b4a',
       stroke: '#000000',
       strokeThickness: 4,
       letterSpacing: 8
     }).setOrigin(0.5);
+
+    const crest = this.add.text(centerX, 60, '⚔️', {
+      fontSize: '32px'
+    }).setOrigin(0.5);
+    this.tweens.add({
+      targets: crest,
+      y: 64,
+      duration: 1200,
+      yoyo: true,
+      repeat: -1,
+      ease: 'Sine.easeInOut'
+    });
     
     // Decorative line
     const line = this.add.graphics();
-    line.lineStyle(2, 0xc9a959, 0.5);
-    line.moveTo(centerX - 100, 210);
-    line.lineTo(centerX + 100, 210);
+    line.lineStyle(2, 0xc9a959, 0.6);
+    line.moveTo(centerX - 140, 210);
+    line.lineTo(centerX + 140, 210);
+    line.strokePath();
+    line.lineStyle(1, 0x5a3f1f, 0.6);
+    line.moveTo(centerX - 120, 216);
+    line.lineTo(centerX + 120, 216);
     line.strokePath();
     
     // Tagline
-    this.add.text(centerX, 235, 'Blood. Honor. Legacy.', {
+    this.add.text(centerX, 238, 'Blood. Honor. Legacy.', {
       fontFamily: 'Georgia, serif',
-      fontSize: '14px',
-      color: '#5a4a3a',
+      fontSize: '15px',
+      color: '#7a5a35',
       fontStyle: 'italic'
     }).setOrigin(0.5);
+
+    this.tweens.add({
+      targets: [title, subtitle],
+      y: '+=2',
+      duration: 1500,
+      yoyo: true,
+      repeat: -1,
+      ease: 'Sine.easeInOut'
+    });
   }
 
   private createMenu(): void {

--- a/src/scenes/ShopScene.ts
+++ b/src/scenes/ShopScene.ts
@@ -5,19 +5,17 @@
 import Phaser from 'phaser';
 import { SaveSystem } from '../systems/SaveSystem';
 import { Fighter } from '../systems/FighterSystem';
-import { WEAPONS_DATA as OLD_WEAPONS, ARMOR_DATA as OLD_ARMOR, COMBAT_ITEMS } from '../data/CombatData';
-import { WEAPONS_DATA } from '../data/WeaponsData';
-import { ARMOR_DATA } from '../data/ArmorData';
+import { COMBAT_ITEMS } from '../data/CombatData';
 import { 
   createItemInstance, 
-  createAffixedItemInstance, 
   ItemInstance, 
   getItemName,
-  getItemData 
+  getItemData,
+  generateRandomWeapon,
+  generateRandomArmor
 } from '../systems/InventorySystem';
 import { getAffixSummary, hasAffixes } from '../systems/AffixSystem';
 import { UIHelper } from '../ui/UIHelper';
-import { RNG } from '../systems/RNGSystem';
 
 export class ShopScene extends Phaser.Scene {
   private gold!: number;
@@ -60,32 +58,17 @@ export class ShopScene extends Phaser.Scene {
     const numWeapons = 3 + Math.floor(meta.promoterLevel / 2);
     const numArmor = 3 + Math.floor(meta.promoterLevel / 2);
     
-    // Filter weapons/armor by league availability
-    const leagueOrder = ['bronze', 'silver', 'gold'];
-    const leagueIdx = leagueOrder.indexOf(league);
-    
     this.shopStock = [];
     
     // Generate weapons as ItemInstances with affixes
-    const availableWeapons = WEAPONS_DATA.filter(w => 
-      leagueOrder.indexOf(w.leagueMin) <= leagueIdx
-    );
-    const weapons = RNG.shuffle([...availableWeapons]).slice(0, numWeapons);
-    weapons.forEach(w => {
-      // Create item instance with affixes rolled based on rarity and league
-      const instance = createAffixedItemInstance(w.id, 'weapon', w.rarity, league);
-      this.shopStock.push(instance);
-    });
+    for (let i = 0; i < numWeapons; i++) {
+      this.shopStock.push(generateRandomWeapon(league, true));
+    }
     
     // Generate armor as ItemInstances with affixes
-    const availableArmor = ARMOR_DATA.filter(a => 
-      leagueOrder.indexOf(a.leagueMin) <= leagueIdx
-    );
-    const armor = RNG.shuffle([...availableArmor]).slice(0, numArmor);
-    armor.forEach(a => {
-      const instance = createAffixedItemInstance(a.id, 'armor', a.rarity, league, a.slot);
-      this.shopStock.push(instance);
-    });
+    for (let i = 0; i < numArmor; i++) {
+      this.shopStock.push(generateRandomArmor(league, undefined, true));
+    }
     
     // Consumables (no affixes)
     COMBAT_ITEMS.forEach(item => {
@@ -100,14 +83,26 @@ export class ShopScene extends Phaser.Scene {
     const { width, height } = this.cameras.main;
     
     const bg = this.add.graphics();
-    bg.fillGradientStyle(0x1a1410, 0x1a1410, 0x2a1f1a, 0x2a1f1a);
+    bg.fillGradientStyle(0x120d0a, 0x1c1410, 0x2b2018, 0x17110c);
     bg.fillRect(0, 0, width, height);
     
     if (this.textures.exists('parchment_overlay')) {
       const overlay = this.add.image(width / 2, height / 2, 'parchment_overlay');
-      overlay.setAlpha(0.08);
+      overlay.setAlpha(0.12);
       overlay.setDisplaySize(width, height);
     }
+
+    const shelves = this.add.graphics();
+    shelves.fillStyle(0x2a1a10, 0.6);
+    shelves.fillRoundedRect(20, 120, width - 40, height - 160, 18);
+    shelves.lineStyle(2, 0x7a5b2e, 0.5);
+    shelves.strokeRoundedRect(20, 120, width - 40, height - 160, 18);
+
+    const banner = this.add.graphics();
+    banner.fillStyle(0x4a1f1a, 0.75);
+    banner.fillRoundedRect(width / 2 - 130, 12, 260, 70, 16);
+    banner.lineStyle(2, 0x9a7b3b, 0.6);
+    banner.strokeRoundedRect(width / 2 - 130, 12, 260, 70, 16);
   }
 
   private createHeader(): void {

--- a/src/systems/LootSystem.ts
+++ b/src/systems/LootSystem.ts
@@ -1,0 +1,54 @@
+/**
+ * LootSystem - Generates loot drops after combat
+ */
+
+import { RNG } from './RNGSystem';
+import { ItemInstance, generateRandomWeapon, generateRandomArmor, generateRandomTrinket, generateRandomConsumable } from './InventorySystem';
+
+export interface LootContext {
+  league: 'bronze' | 'silver' | 'gold';
+  crowdHype: number;
+  consecutiveWins: number;
+}
+
+export function generateLootDrops(context: LootContext): ItemInstance[] {
+  const drops: ItemInstance[] = [];
+  const hypeBonus = Math.min(0.35, context.crowdHype / 300);
+  const baseDrops = 1 + (context.consecutiveWins >= 3 ? 1 : 0);
+
+  for (let i = 0; i < baseDrops; i++) {
+    drops.push(generateLootItem(context.league));
+  }
+
+  if (RNG.chance(0.25 + hypeBonus)) {
+    drops.push(generateLootItem(context.league));
+  }
+
+  if (context.consecutiveWins >= 5 && RNG.chance(0.35)) {
+    drops.push(generateLootItem(context.league));
+  }
+
+  return drops;
+}
+
+function generateLootItem(league: 'bronze' | 'silver' | 'gold'): ItemInstance {
+  const category = RNG.weightedPick([
+    ['weapon', 35],
+    ['armor', 35],
+    ['trinket', 15],
+    ['consumable', 15]
+  ] as const);
+
+  switch (category) {
+    case 'weapon':
+      return generateRandomWeapon(league, true);
+    case 'armor':
+      return generateRandomArmor(league, undefined, true);
+    case 'trinket':
+      return generateRandomTrinket(league);
+    case 'consumable':
+      return generateRandomConsumable(league);
+    default:
+      return generateRandomWeapon(league, true);
+  }
+}


### PR DESCRIPTION
### Motivation
- Improve visual polish and readability across key scenes to make menus, shop, results, and combat feel more cinematic and tactical. 
- Surface procedural item generation and persistent loot into UI flows so drops and vendor stock reflect varied generated gear. 
- Expose new combat telemetry (momentum, posture, intent, injuries) in the HUD to make tactical systems more visible to players.

### Description
- Revamped main menu backdrop and title treatment with layered gradients, radial glow, vignette, framing, animated crest and gentle title tweens (updated `src/scenes/MainMenuScene.ts`).
- Enhanced shop and results backgrounds with shelf/banner framing, spotlights and decorative borders, and integrated loot display into the results flow (updated `src/scenes/ShopScene.ts` and `src/scenes/ResultsScene.ts`).
- Expanded fight UI with a HUD panel, richer health/stamina/focus/injury bars, momentum/parry/intent texts, combat feed, banners, ambient banners and dust motes, and action panel styling (updated `src/scenes/FightScene.ts`).
- Added procedural weapon and armor builders and hooks into inventory generation, rarity rolling, and shop/drops, including `createProceduralWeaponId`/`createProceduralArmorId`, `buildProceduralWeapon`/`buildProceduralArmor`, and `generateProceduralWeapon`/`generateProceduralArmor` (updates to `src/data/WeaponsData.ts`, `src/data/ArmorData.ts`, and `src/systems/InventorySystem.ts`).
- Introduced a loot generator `src/systems/LootSystem.ts` and wired results to persist generated drops into saves (used in `ResultsScene`).
- Polished combat systems to surface and track momentum/posture/stun interactions and adjust turn-end upkeep (changes in `src/systems/CombatSystem.ts`).

### Testing
- Launched the dev server with `npm run dev` which reported Vite ready and served at the expected URL but produced a non-fatal `spawn xdg-open ENOENT` when attempting to open the browser. 
- Captured a Playwright screenshot of the main menu (`artifacts/main-menu-ui.png`) to validate visual changes successfully. 
- Changes were committed locally (`Enhance UI presentation for key scenes`) and no automated unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983c5e910c08324bbc1be2f1c4d857d)