### PR TITLE
Add procedural loot, seeded weapon icon variants, and combat/UI polish

### DIFF
--- a/src/data/WeaponsData.ts
+++ b/src/data/WeaponsData.ts
@@ -3,6 +3,8 @@
  * 40+ weapons across 8 weapon types with distinct feels
  */
 
+import { SeededRNG } from '../systems/RNGSystem';
+
 export type WeaponType = 
   | 'sword' 
   | 'axe' 
@@ -54,6 +56,226 @@ export interface WeaponData {
   price: number;
   sellPrice: number;
   leagueMin: 'bronze' | 'silver' | 'gold';  // Minimum league to find
+}
+
+export const PROCEDURAL_WEAPON_PREFIX = 'proc_weapon';
+
+export function createProceduralWeaponId(
+  seed: number,
+  league: 'bronze' | 'silver' | 'gold',
+  rarity: ItemRarity,
+  type: WeaponType
+): string {
+  return `${PROCEDURAL_WEAPON_PREFIX}_${seed}_${league}_${rarity}_${type}`;
+}
+
+const PROCEDURAL_WEAPON_ADJECTIVES = [
+  'Jagged',
+  'Gleaming',
+  'Ancient',
+  'Severing',
+  'Vicious',
+  'Honed',
+  'Stormforged',
+  'Gilded',
+  'Ruthless',
+  'Warlord\'s',
+  'Grim',
+  'Bloodstained',
+  'Ironbound',
+  'Whispering',
+  'Cinder',
+  'Dread',
+  'Nightsteel'
+];
+
+const PROCEDURAL_WEAPON_MATERIALS = [
+  'Iron',
+  'Steel',
+  'Obsidian',
+  'Bronze',
+  'Crimson',
+  'Moonsteel',
+  'Ashen',
+  'Blackened',
+  'Sunforged',
+  'Runed'
+];
+
+const PROCEDURAL_WEAPON_SUFFIXES = [
+  'of the Pit',
+  'of Cinders',
+  'of Triumph',
+  'of the Dunes',
+  'of the Bloodline',
+  'of the Coliseum',
+  'of the Pact',
+  'of the Betrayer',
+  'of Last Light'
+];
+
+const WEAPON_ICON_VARIANTS: Record<WeaponType, string[]> = {
+  sword: ['⚔️', '🗡️', '🗡️'],
+  axe: ['🪓', '⚒️'],
+  mace: ['🔨', '⚒️'],
+  spear: ['🔱', '🗡️'],
+  dagger: ['🗡️', '🔪'],
+  greatsword: ['⚔️', '🗡️'],
+  flail: ['⛓️', '🔨'],
+  hammer: ['🔨', '⚒️']
+};
+
+function getWeaponIconVariant(rng: SeededRNG, type: WeaponType): string {
+  const pool = WEAPON_ICON_VARIANTS[type] || ['⚔️'];
+  return rng.pick(pool);
+}
+
+export function getWeaponIconVariantForSeed(seed: number, type: WeaponType): string {
+  const rng = new SeededRNG(seed);
+  return getWeaponIconVariant(rng, type);
+}
+
+const WEAPON_TYPE_BONUSES: Record<WeaponType, { damage: number; accuracy: number; crit: number; speed: number; lightCost: number; heavyCost: number }> = {
+  sword: { damage: 1, accuracy: 3, crit: 1, speed: 1, lightCost: 10, heavyCost: 22 },
+  axe: { damage: 2, accuracy: -2, crit: 2, speed: -1, lightCost: 12, heavyCost: 25 },
+  mace: { damage: 2, accuracy: -1, crit: 0, speed: -1, lightCost: 12, heavyCost: 24 },
+  spear: { damage: 1, accuracy: 5, crit: 1, speed: 0, lightCost: 10, heavyCost: 22 },
+  dagger: { damage: 0, accuracy: 6, crit: 4, speed: 2, lightCost: 8, heavyCost: 18 },
+  greatsword: { damage: 3, accuracy: -4, crit: 2, speed: -3, lightCost: 14, heavyCost: 28 },
+  flail: { damage: 2, accuracy: -3, crit: 3, speed: -2, lightCost: 12, heavyCost: 26 },
+  hammer: { damage: 3, accuracy: -5, crit: 1, speed: -3, lightCost: 14, heavyCost: 30 }
+};
+
+function getRarityTier(rarity: ItemRarity): number {
+  switch (rarity) {
+    case 'common':
+      return 1;
+    case 'uncommon':
+      return 2;
+    case 'rare':
+      return 3;
+    case 'epic':
+      return 4;
+    case 'legendary':
+      return 5;
+  }
+}
+
+function getLeagueMultiplier(league: 'bronze' | 'silver' | 'gold'): number {
+  switch (league) {
+    case 'silver':
+      return 1.15;
+    case 'gold':
+      return 1.3;
+    default:
+      return 1;
+  }
+}
+
+function parseProceduralWeaponId(id: string): { seed: number; league: 'bronze' | 'silver' | 'gold'; rarity: ItemRarity; type: WeaponType } | null {
+  if (!id.startsWith(`${PROCEDURAL_WEAPON_PREFIX}_`)) return null;
+  const parts = id.split('_');
+  if (parts.length < 6) return null;
+  const seed = Number(parts[2]);
+  const league = parts[3] as 'bronze' | 'silver' | 'gold';
+  const rarity = parts[4] as ItemRarity;
+  const type = parts[5] as WeaponType;
+  if (!Number.isFinite(seed)) return null;
+  return { seed, league, rarity, type };
+}
+
+function buildProceduralWeapon(id: string): WeaponData | undefined {
+  const parsed = parseProceduralWeaponId(id);
+  if (!parsed) return undefined;
+  const { seed, league, rarity } = parsed;
+  const resolvedType: WeaponType = WEAPON_TYPE_INFO[parsed.type] ? parsed.type : 'sword';
+  const rng = new SeededRNG(seed);
+  const tier = getRarityTier(rarity);
+  const leagueMultiplier = getLeagueMultiplier(league);
+  const typeBonus = WEAPON_TYPE_BONUSES[resolvedType] ?? WEAPON_TYPE_BONUSES.sword;
+
+  const adjective = rng.pick(PROCEDURAL_WEAPON_ADJECTIVES);
+  const material = rng.pick(PROCEDURAL_WEAPON_MATERIALS);
+  const suffix = rng.pick(PROCEDURAL_WEAPON_SUFFIXES);
+  const name = `${adjective} ${material} ${WEAPON_TYPE_INFO[resolvedType].name} ${suffix}`;
+  const icon = getWeaponIconVariant(rng, resolvedType);
+
+  const baseMin = Math.round((4 + tier * 2 + rng.randomInt(0, tier + 2)) * leagueMultiplier + typeBonus.damage);
+  const baseMax = Math.round((baseMin + 3 + rng.randomInt(0, 4 + tier)) * leagueMultiplier);
+  const accuracyMod = typeBonus.accuracy + rng.randomInt(-2, 3) + tier;
+  const critChanceMod = typeBonus.crit + rng.randomInt(0, 3) + Math.floor(tier / 2);
+  const speedMod = typeBonus.speed + rng.randomInt(-1, 2);
+  const lightStaminaCost = Math.max(6, typeBonus.lightCost - Math.floor(tier / 2));
+  const heavyStaminaCost = Math.max(14, typeBonus.heavyCost - Math.floor(tier / 2));
+
+  const effects: WeaponEffect[] = [];
+  const effectPool: WeaponEffect[] = [
+    { type: 'bleed', chance: rng.randomFloat(0.12, 0.3), value: rng.randomInt(2, 4 + tier), description: '' },
+    { type: 'stun', chance: rng.randomFloat(0.08, 0.2), value: rng.randomInt(1, 1 + Math.floor(tier / 2)), description: '' },
+    { type: 'armor_break', chance: rng.randomFloat(0.12, 0.3), value: rng.randomInt(2, 5 + tier), description: '' },
+    { type: 'crit_bonus', chance: rng.randomFloat(0.15, 0.35), value: rng.randomInt(5, 8 + tier * 2), description: '' },
+    { type: 'first_strike', chance: rng.randomFloat(0.15, 0.3), value: rng.randomInt(5, 10 + tier * 2), description: '' },
+    { type: 'guard_crush', chance: rng.randomFloat(0.1, 0.25), value: rng.randomInt(10, 20 + tier * 5), description: '' },
+    { type: 'lifesteal', chance: rng.randomFloat(0.12, 0.25), value: rng.randomInt(5, 10 + tier * 3), description: '' },
+    { type: 'focus_gain', chance: rng.randomFloat(0.2, 0.35), value: rng.randomInt(3, 6 + tier), description: '' },
+    { type: 'momentum_gain', chance: rng.randomFloat(0.2, 0.35), value: rng.randomInt(1, 2 + Math.floor(tier / 2)), description: '' },
+    { type: 'poison', chance: rng.randomFloat(0.1, 0.22), value: rng.randomInt(2, 4 + tier), description: '' }
+  ];
+
+  const effectCount = tier >= 5 ? 3 : tier >= 4 ? 2 : tier >= 3 ? 1 : 0;
+  if (effectCount > 0) {
+    rng.pickMultiple(effectPool, effectCount).forEach(effect => {
+      const description = (() => {
+        switch (effect.type) {
+          case 'bleed':
+            return `${Math.round(effect.chance * 100)}% bleed for ${effect.value}`;
+          case 'stun':
+            return `${Math.round(effect.chance * 100)}% stun for ${effect.value} turns`;
+          case 'armor_break':
+            return `${Math.round(effect.chance * 100)}% armor break ${effect.value}`;
+          case 'crit_bonus':
+            return `${Math.round(effect.chance * 100)}% crits deal +${effect.value}%`;
+          case 'first_strike':
+            return `${Math.round(effect.chance * 100)}% first strike +${effect.value}%`;
+          case 'guard_crush':
+            return `${Math.round(effect.chance * 100)}% guard crush ${effect.value}%`;
+          case 'lifesteal':
+            return `${Math.round(effect.chance * 100)}% lifesteal ${effect.value}%`;
+          case 'focus_gain':
+            return `${Math.round(effect.chance * 100)}% gain ${effect.value} focus`;
+          case 'momentum_gain':
+            return `${Math.round(effect.chance * 100)}% gain ${effect.value} momentum`;
+          case 'poison':
+            return `${Math.round(effect.chance * 100)}% poison for ${effect.value}`;
+        }
+      })();
+      effects.push({ ...effect, description });
+    });
+  }
+
+  const price = Math.round((baseMax + baseMin) * 6 + tier * 35);
+  const sellPrice = Math.round(price * 0.35);
+
+  return {
+    id,
+    name,
+    type: resolvedType,
+    rarity,
+    icon,
+    damageMin: baseMin,
+    damageMax: baseMax,
+    lightStaminaCost,
+    heavyStaminaCost,
+    accuracyMod,
+    critChanceMod,
+    speedMod,
+    effects,
+    damageDescription: `Light: ${material.toLowerCase()} slash. Heavy: ${adjective.toLowerCase()} cleave.`,
+    lore: `Forged in the ${league} pits, whispered to bear ${adjective.toLowerCase()} fury.`,
+    price,
+    sellPrice,
+    leagueMin: league
+  };
 }
 
 // Weapon type base characteristics
@@ -777,6 +999,9 @@ export const WEAPONS_DATA: WeaponData[] = [
 
 // Helper functions
 export function getWeaponById(id: string): WeaponData | undefined {
+  if (id.startsWith(`${PROCEDURAL_WEAPON_PREFIX}_`)) {
+    return buildProceduralWeapon(id);
+  }
   return WEAPONS_DATA.find(w => w.id === id);
 }
 

--- a/src/scenes/MainMenuScene.ts
+++ b/src/scenes/MainMenuScene.ts
@@ -41,23 +41,37 @@ export class MainMenuScene extends Phaser.Scene {
   private createBackground(): void {
     const { width, height } = this.cameras.main;
     
-    // Dark gradient background
+    // Dark gradient background with depth
     const bg = this.add.graphics();
-    bg.fillGradientStyle(0x1a1410, 0x1a1410, 0x2a1f1a, 0x2a1f1a);
+    bg.fillGradientStyle(0x120d0a, 0x1c1410, 0x2c2018, 0x1a1410);
     bg.fillRect(0, 0, width, height);
+
+    // Subtle radial glow
+    const glow = this.add.graphics();
+    glow.fillStyle(0xffd37a, 0.12);
+    glow.fillCircle(width * 0.5, height * 0.3, width * 0.35);
+    glow.fillStyle(0x7a4b1d, 0.18);
+    glow.fillCircle(width * 0.5, height * 0.35, width * 0.2);
     
     // Add parchment texture overlay
     if (this.textures.exists('parchment_overlay')) {
       const overlay = this.add.image(width / 2, height / 2, 'parchment_overlay');
-      overlay.setAlpha(0.1);
+      overlay.setAlpha(0.12);
       overlay.setDisplaySize(width, height);
     }
+
+    // Decorative frame
+    const frame = this.add.graphics();
+    frame.lineStyle(3, 0x7a5b2e, 0.7);
+    frame.strokeRoundedRect(16, 18, width - 32, height - 36, 16);
+    frame.lineStyle(1, 0x2a1f1a, 0.9);
+    frame.strokeRoundedRect(22, 26, width - 44, height - 52, 14);
     
     // Add vignette
     if (this.textures.exists('vignette')) {
       const vignette = this.add.image(width / 2, height / 2, 'vignette');
       vignette.setDisplaySize(width, height);
-      vignette.setAlpha(0.5);
+      vignette.setAlpha(0.6);
     }
   }
 
@@ -66,37 +80,62 @@ export class MainMenuScene extends Phaser.Scene {
     const centerX = width / 2;
     
     // Main title
-    const title = this.add.text(centerX, 120, 'BLOODLINE', {
+    const title = this.add.text(centerX, 110, 'BLOODLINE', {
       fontFamily: 'Georgia, serif',
-      fontSize: '48px',
-      color: '#c9a959',
+      fontSize: '52px',
+      color: '#f1d28a',
       stroke: '#000000',
-      strokeThickness: 6
+      strokeThickness: 7
     }).setOrigin(0.5);
     
-    const subtitle = this.add.text(centerX, 175, 'ARENA', {
+    const subtitle = this.add.text(centerX, 170, 'ARENA', {
       fontFamily: 'Georgia, serif',
-      fontSize: '36px',
-      color: '#8b7355',
+      fontSize: '38px',
+      color: '#b98b4a',
       stroke: '#000000',
       strokeThickness: 4,
       letterSpacing: 8
     }).setOrigin(0.5);
+
+    const crest = this.add.text(centerX, 60, '⚔️', {
+      fontSize: '32px'
+    }).setOrigin(0.5);
+    this.tweens.add({
+      targets: crest,
+      y: 64,
+      duration: 1200,
+      yoyo: true,
+      repeat: -1,
+      ease: 'Sine.easeInOut'
+    });
     
     // Decorative line
     const line = this.add.graphics();
-    line.lineStyle(2, 0xc9a959, 0.5);
-    line.moveTo(centerX - 100, 210);
-    line.lineTo(centerX + 100, 210);
+    line.lineStyle(2, 0xc9a959, 0.6);
+    line.moveTo(centerX - 140, 210);
+    line.lineTo(centerX + 140, 210);
+    line.strokePath();
+    line.lineStyle(1, 0x5a3f1f, 0.6);
+    line.moveTo(centerX - 120, 216);
+    line.lineTo(centerX + 120, 216);
     line.strokePath();
     
     // Tagline
-    this.add.text(centerX, 235, 'Blood. Honor. Legacy.', {
+    this.add.text(centerX, 238, 'Blood. Honor. Legacy.', {
       fontFamily: 'Georgia, serif',
-      fontSize: '14px',
-      color: '#5a4a3a',
+      fontSize: '15px',
+      color: '#7a5a35',
       fontStyle: 'italic'
     }).setOrigin(0.5);
+
+    this.tweens.add({
+      targets: [title, subtitle],
+      y: '+=2',
+      duration: 1500,
+      yoyo: true,
+      repeat: -1,
+      ease: 'Sine.easeInOut'
+    });
   }
 
   private createMenu(): void {

--- a/src/scenes/ShopScene.ts
+++ b/src/scenes/ShopScene.ts
@@ -5,19 +5,17 @@
 import Phaser from 'phaser';
 import { SaveSystem } from '../systems/SaveSystem';
 import { Fighter } from '../systems/FighterSystem';
-import { WEAPONS_DATA as OLD_WEAPONS, ARMOR_DATA as OLD_ARMOR, COMBAT_ITEMS } from '../data/CombatData';
-import { WEAPONS_DATA } from '../data/WeaponsData';
-import { ARMOR_DATA } from '../data/ArmorData';
+import { COMBAT_ITEMS } from '../data/CombatData';
 import { 
   createItemInstance, 
-  createAffixedItemInstance, 
   ItemInstance, 
   getItemName,
-  getItemData 
+  getItemData,
+  generateRandomWeapon,
+  generateRandomArmor
 } from '../systems/InventorySystem';
 import { getAffixSummary, hasAffixes } from '../systems/AffixSystem';
 import { UIHelper } from '../ui/UIHelper';
-import { RNG } from '../systems/RNGSystem';
 
 export class ShopScene extends Phaser.Scene {
   private gold!: number;
@@ -60,32 +58,17 @@ export class ShopScene extends Phaser.Scene {
     const numWeapons = 3 + Math.floor(meta.promoterLevel / 2);
     const numArmor = 3 + Math.floor(meta.promoterLevel / 2);
     
-    // Filter weapons/armor by league availability
-    const leagueOrder = ['bronze', 'silver', 'gold'];
-    const leagueIdx = leagueOrder.indexOf(league);
-    
     this.shopStock = [];
     
     // Generate weapons as ItemInstances with affixes
-    const availableWeapons = WEAPONS_DATA.filter(w => 
-      leagueOrder.indexOf(w.leagueMin) <= leagueIdx
-    );
-    const weapons = RNG.shuffle([...availableWeapons]).slice(0, numWeapons);
-    weapons.forEach(w => {
-      // Create item instance with affixes rolled based on rarity and league
-      const instance = createAffixedItemInstance(w.id, 'weapon', w.rarity, league);
-      this.shopStock.push(instance);
-    });
+    for (let i = 0; i < numWeapons; i++) {
+      this.shopStock.push(generateRandomWeapon(league, true));
+    }
     
     // Generate armor as ItemInstances with affixes
-    const availableArmor = ARMOR_DATA.filter(a => 
-      leagueOrder.indexOf(a.leagueMin) <= leagueIdx
-    );
-    const armor = RNG.shuffle([...availableArmor]).slice(0, numArmor);
-    armor.forEach(a => {
-      const instance = createAffixedItemInstance(a.id, 'armor', a.rarity, league, a.slot);
-      this.shopStock.push(instance);
-    });
+    for (let i = 0; i < numArmor; i++) {
+      this.shopStock.push(generateRandomArmor(league, undefined, true));
+    }
     
     // Consumables (no affixes)
     COMBAT_ITEMS.forEach(item => {
@@ -100,14 +83,26 @@ export class ShopScene extends Phaser.Scene {
     const { width, height } = this.cameras.main;
     
     const bg = this.add.graphics();
-    bg.fillGradientStyle(0x1a1410, 0x1a1410, 0x2a1f1a, 0x2a1f1a);
+    bg.fillGradientStyle(0x120d0a, 0x1c1410, 0x2b2018, 0x17110c);
     bg.fillRect(0, 0, width, height);
     
     if (this.textures.exists('parchment_overlay')) {
       const overlay = this.add.image(width / 2, height / 2, 'parchment_overlay');
-      overlay.setAlpha(0.08);
+      overlay.setAlpha(0.12);
       overlay.setDisplaySize(width, height);
     }
+
+    const shelves = this.add.graphics();
+    shelves.fillStyle(0x2a1a10, 0.6);
+    shelves.fillRoundedRect(20, 120, width - 40, height - 160, 18);
+    shelves.lineStyle(2, 0x7a5b2e, 0.5);
+    shelves.strokeRoundedRect(20, 120, width - 40, height - 160, 18);
+
+    const banner = this.add.graphics();
+    banner.fillStyle(0x4a1f1a, 0.75);
+    banner.fillRoundedRect(width / 2 - 130, 12, 260, 70, 16);
+    banner.lineStyle(2, 0x9a7b3b, 0.6);
+    banner.strokeRoundedRect(width / 2 - 130, 12, 260, 70, 16);
   }
 
   private createHeader(): void {

--- a/src/systems/InventorySystem.ts
+++ b/src/systems/InventorySystem.ts
@@ -3,9 +3,10 @@
  * Handles item instances, equipment, consumables, and stat calculations
  */
 
-import { WeaponData, ItemRarity, getWeaponById, WEAPONS_DATA } from '../data/WeaponsData';
-import { ArmorData, ArmorSlot, getArmorById, ARMOR_DATA } from '../data/ArmorData';
+import { WeaponData, ItemRarity, getWeaponById, WEAPONS_DATA, WEAPON_TYPE_INFO, WeaponType, createProceduralWeaponId, getWeaponIconVariantForSeed } from '../data/WeaponsData';
+import { ArmorData, ArmorSlot, getArmorById, ARMOR_DATA, ARMOR_SLOT_INFO, createProceduralArmorId } from '../data/ArmorData';
 import { rollAffixes, getAffixedItemName, calculateAffixStats, AffixedItemInstance, AffixedStats } from './AffixSystem';
+import { RNG } from './RNGSystem';
 
 // ========== ITEM TYPES ==========
 
@@ -365,6 +366,37 @@ export const CONSUMABLES_DATA: ConsumableData[] = [
   }
 ];
 
+const RARITY_WEIGHTS: Record<ItemRarity, number> = {
+  common: 50,
+  uncommon: 30,
+  rare: 15,
+  epic: 4,
+  legendary: 1
+};
+
+function rollRarityForLeague(league: 'bronze' | 'silver' | 'gold'): ItemRarity {
+  const weights = { ...RARITY_WEIGHTS };
+  if (league === 'silver') {
+    weights.rare += 5;
+    weights.epic += 2;
+  } else if (league === 'gold') {
+    weights.rare += 10;
+    weights.epic += 5;
+    weights.legendary += 2;
+  }
+  const options: [ItemRarity, number][] = Object.entries(weights) as [ItemRarity, number][];
+  return RNG.weightedPick(options);
+}
+
+function hashStringToSeed(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash << 5) - hash + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash) || 1;
+}
+
 // ========== HELPER FUNCTIONS ==========
 
 export function getTrinketById(id: string): TrinketData | undefined {
@@ -456,6 +488,10 @@ export function getBaseItemName(instance: ItemInstance): string {
 
 export function getItemIcon(instance: ItemInstance): string {
   const data = getItemData(instance);
+  if (instance.itemType === 'weapon' && data && 'type' in data) {
+    const seed = hashStringToSeed(instance.instanceId);
+    return getWeaponIconVariantForSeed(seed, data.type as WeaponType);
+  }
   return data?.icon || '❓';
 }
 
@@ -714,37 +750,22 @@ export const RARITY_NAMES: Record<ItemRarity, string> = {
 // ========== ITEM GENERATION FOR DROPS/SHOP ==========
 
 export function generateRandomWeapon(league: 'bronze' | 'silver' | 'gold', withAffixes: boolean = true): ItemInstance {
+  const proceduralChance = league === 'gold' ? 0.6 : league === 'silver' ? 0.45 : 0.3;
+  if (RNG.chance(proceduralChance)) {
+    return generateProceduralWeapon(league, withAffixes);
+  }
+
   const leagueOrder = ['bronze', 'silver', 'gold'];
   const leagueIdx = leagueOrder.indexOf(league);
-  
+
   const available = WEAPONS_DATA.filter(w => leagueOrder.indexOf(w.leagueMin) <= leagueIdx);
-  
-  // Weight by rarity (common more likely)
-  const rarityWeights: Record<ItemRarity, number> = {
-    common: 50,
-    uncommon: 30,
-    rare: 15,
-    epic: 4,
-    legendary: 1
-  };
-  
-  // Increase rare chances in higher leagues
-  if (league === 'silver') {
-    rarityWeights.rare += 5;
-    rarityWeights.epic += 2;
-  } else if (league === 'gold') {
-    rarityWeights.rare += 10;
-    rarityWeights.epic += 5;
-    rarityWeights.legendary += 1;
-  }
-  
   const weighted = available.map(w => ({
     weapon: w,
-    weight: rarityWeights[w.rarity]
+    weight: RARITY_WEIGHTS[w.rarity]
   }));
   
   const totalWeight = weighted.reduce((sum, w) => sum + w.weight, 0);
-  let roll = Math.random() * totalWeight;
+  let roll = RNG.float(0, totalWeight);
   
   for (const { weapon, weight } of weighted) {
     roll -= weight;
@@ -764,6 +785,11 @@ export function generateRandomWeapon(league: 'bronze' | 'silver' | 'gold', withA
 }
 
 export function generateRandomArmor(league: 'bronze' | 'silver' | 'gold', slot?: ArmorSlot, withAffixes: boolean = true): ItemInstance {
+  const proceduralChance = league === 'gold' ? 0.6 : league === 'silver' ? 0.45 : 0.3;
+  if (RNG.chance(proceduralChance)) {
+    return generateProceduralArmor(league, slot, withAffixes);
+  }
+
   const leagueOrder = ['bronze', 'silver', 'gold'];
   const leagueIdx = leagueOrder.indexOf(league);
   
@@ -772,30 +798,13 @@ export function generateRandomArmor(league: 'bronze' | 'silver' | 'gold', slot?:
     available = available.filter(a => a.slot === slot);
   }
   
-  const rarityWeights: Record<ItemRarity, number> = {
-    common: 50,
-    uncommon: 30,
-    rare: 15,
-    epic: 4,
-    legendary: 1
-  };
-  
-  if (league === 'silver') {
-    rarityWeights.rare += 5;
-    rarityWeights.epic += 2;
-  } else if (league === 'gold') {
-    rarityWeights.rare += 10;
-    rarityWeights.epic += 5;
-    rarityWeights.legendary += 1;
-  }
-  
   const weighted = available.map(a => ({
     armor: a,
-    weight: rarityWeights[a.rarity]
+    weight: RARITY_WEIGHTS[a.rarity]
   }));
   
   const totalWeight = weighted.reduce((sum, a) => sum + a.weight, 0);
-  let roll = Math.random() * totalWeight;
+  let roll = RNG.float(0, totalWeight);
   
   for (const { armor, weight } of weighted) {
     roll -= weight;
@@ -812,4 +821,44 @@ export function generateRandomArmor(league: 'bronze' | 'silver' | 'gold', slot?:
     return createAffixedItemInstance(first.id, 'armor', first.rarity, league, first.slot);
   }
   return createItemInstance(first.id, 'armor', first.slot);
+}
+
+export function generateProceduralWeapon(league: 'bronze' | 'silver' | 'gold', withAffixes: boolean = true): ItemInstance {
+  const rarity = rollRarityForLeague(league);
+  const type = RNG.pick(Object.keys(WEAPON_TYPE_INFO) as WeaponType[]);
+  const seed = RNG.int(100000, 999999);
+  const id = createProceduralWeaponId(seed, league, rarity, type);
+  if (withAffixes) {
+    return createAffixedItemInstance(id, 'weapon', rarity, league);
+  }
+  return createItemInstance(id, 'weapon');
+}
+
+export function generateProceduralArmor(league: 'bronze' | 'silver' | 'gold', slot?: ArmorSlot, withAffixes: boolean = true): ItemInstance {
+  const rarity = rollRarityForLeague(league);
+  const resolvedSlot = slot ?? RNG.pick(Object.keys(ARMOR_SLOT_INFO) as ArmorSlot[]);
+  const seed = RNG.int(100000, 999999);
+  const id = createProceduralArmorId(seed, league, rarity, resolvedSlot);
+  if (withAffixes) {
+    return createAffixedItemInstance(id, 'armor', rarity, league, resolvedSlot);
+  }
+  return createItemInstance(id, 'armor', resolvedSlot);
+}
+
+export function generateRandomTrinket(league: 'bronze' | 'silver' | 'gold'): ItemInstance {
+  const leagueOrder = ['bronze', 'silver', 'gold'];
+  const leagueIdx = leagueOrder.indexOf(league);
+  const available = TRINKETS_DATA.filter(t => leagueOrder.indexOf(t.leagueMin) <= leagueIdx);
+  const weighted = available.map(t => [t, RARITY_WEIGHTS[t.rarity]] as [TrinketData, number]);
+  const picked = RNG.weightedPick(weighted);
+  return createItemInstance(picked.id, 'trinket');
+}
+
+export function generateRandomConsumable(league: 'bronze' | 'silver' | 'gold'): ItemInstance {
+  const leagueOrder = ['bronze', 'silver', 'gold'];
+  const leagueIdx = leagueOrder.indexOf(league);
+  const available = CONSUMABLES_DATA.filter(c => leagueOrder.indexOf(c.leagueMin) <= leagueIdx);
+  const weighted = available.map(c => [c, RARITY_WEIGHTS[c.rarity]] as [ConsumableData, number]);
+  const picked = RNG.weightedPick(weighted);
+  return createItemInstance(picked.id, 'consumable', undefined, 1);
 }

--- a/src/systems/LootSystem.ts
+++ b/src/systems/LootSystem.ts
@@ -1,0 +1,54 @@
+/**
+ * LootSystem - Generates loot drops after combat
+ */
+
+import { RNG } from './RNGSystem';
+import { ItemInstance, generateRandomWeapon, generateRandomArmor, generateRandomTrinket, generateRandomConsumable } from './InventorySystem';
+
+export interface LootContext {
+  league: 'bronze' | 'silver' | 'gold';
+  crowdHype: number;
+  consecutiveWins: number;
+}
+
+export function generateLootDrops(context: LootContext): ItemInstance[] {
+  const drops: ItemInstance[] = [];
+  const hypeBonus = Math.min(0.35, context.crowdHype / 300);
+  const baseDrops = 1 + (context.consecutiveWins >= 3 ? 1 : 0);
+
+  for (let i = 0; i < baseDrops; i++) {
+    drops.push(generateLootItem(context.league));
+  }
+
+  if (RNG.chance(0.25 + hypeBonus)) {
+    drops.push(generateLootItem(context.league));
+  }
+
+  if (context.consecutiveWins >= 5 && RNG.chance(0.35)) {
+    drops.push(generateLootItem(context.league));
+  }
+
+  return drops;
+}
+
+function generateLootItem(league: 'bronze' | 'silver' | 'gold'): ItemInstance {
+  const category = RNG.weightedPick([
+    ['weapon', 35],
+    ['armor', 35],
+    ['trinket', 15],
+    ['consumable', 15]
+  ] as const);
+
+  switch (category) {
+    case 'weapon':
+      return generateRandomWeapon(league, true);
+    case 'armor':
+      return generateRandomArmor(league, undefined, true);
+    case 'trinket':
+      return generateRandomTrinket(league);
+    case 'consumable':
+      return generateRandomConsumable(league);
+    default:
+      return generateRandomWeapon(league, true);
+  }
+}


### PR DESCRIPTION
### Motivation
- Increase visual variety and clarity for weapons and HUD while surfacing procedural loot in shop/results flows. 
- Make procedural gear deterministic per-instance so visuals and generated stats remain consistent across sessions. 
- Surface combat telemetry (momentum, posture, intent, injuries) to improve tactical feedback to players.

### Description
- Added seeded weapon icon variants and selection utilities (`getWeaponIconVariantForSeed`) and wire-in deterministic per-instance icons via `getItemIcon` in `InventorySystem` using a `hashStringToSeed` helper. 
- Implemented procedural weapon and armor builders and IDs (`createProceduralWeaponId`, `createProceduralArmorId`, `buildProceduralWeapon`, `buildProceduralArmor`) and exposed `generateProceduralWeapon`/`generateProceduralArmor` along with `generateRandomWeapon`/`generateRandomArmor` to pick procedural vs. catalog items. 
- Introduced a `LootSystem` (`src/systems/LootSystem.ts`) that generates context-aware drops and integrated it into `ResultsScene` to display and persist recovered loot. 
- Updated shop flows to use `generateRandomWeapon`/`generateRandomArmor` so vendor stock can contain procedural items. 
- Expanded combat and UI feedback: HUD panel, health/stamina/focus/injury bars, momentum/parry/intent texts, combat feed, ambient decorations, and richer fight scene visuals (`FightScene.ts`, `MainMenuScene.ts`, `ShopScene.ts`, `ResultsScene.ts`). 
- Enhanced combat rules to track `momentumStacks`, `posture`, guard-break behavior, stun/poison bleed processing, and updated end-of-turn upkeep to regenerate posture and stamina (`CombatSystem.ts`).

### Testing
- Dev server launched with `npm run dev` and Vite reported ready on the expected port; the `spawn xdg-open ENOENT` was logged but was non-fatal and did not block serving. (Succeeded with a non-fatal helper error.)
- Ran an automated Playwright session to navigate the app and capture a screenshot of the shop UI, producing `artifacts/shop-ui.png` which demonstrates weapon icon variety and updated shop visuals. (Screenshot generated successfully.)
- No automated unit tests were run as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983c5e910c08324bbc1be2f1c4d857d)